### PR TITLE
Added basic schema parsing

### DIFF
--- a/cmd/parquet-cli/cmd_schema.go
+++ b/cmd/parquet-cli/cmd_schema.go
@@ -1,12 +1,145 @@
 package main
 
-import "fmt"
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/segmentio/encoding/thrift"
+	"github.com/segmentio/parquet-go/format"
+	"github.com/stoewer/parquet-cli/pkg/output"
+)
 
 type schema struct {
+	outputOptions
 	File string `arg:""`
 }
 
 func (s *schema) Run() error {
-	fmt.Println("Sub command schema not implemented yet")
-	return nil
+	f, err := os.Open(s.File)
+	if err != nil {
+		return err
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	metadata, err := readMetadata(f, fi.Size())
+	if err != nil {
+		return err
+
+	}
+
+	return output.Print(os.Stdout, s.Output, newMetadataTable(metadata))
+}
+
+// borrowed with love from github.com/segmentio/parquet-go/file.go:OpenFile()
+func readMetadata(r io.ReaderAt, size int64) (*format.FileMetaData, error) {
+	b := make([]byte, 8)
+
+	if _, err := r.ReadAt(b[:4], 0); err != nil {
+		return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
+	}
+	if string(b[:4]) != "PAR1" {
+		return nil, fmt.Errorf("invalid magic header of parquet file: %q", b[:4])
+	}
+	if n, err := r.ReadAt(b[:8], size-8); n != 8 {
+		return nil, fmt.Errorf("reading magic footer of parquet file: %w", err)
+	}
+	if string(b[4:8]) != "PAR1" {
+		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", b[4:8])
+	}
+
+	footerSize := int64(binary.LittleEndian.Uint32(b[:4]))
+	footerData := make([]byte, footerSize)
+	if _, err := r.ReadAt(footerData, size-(footerSize+8)); err != nil {
+		return nil, fmt.Errorf("reading footer of parquet file: %w", err)
+	}
+
+	protocol := thrift.CompactProtocol{}
+	metadata := &format.FileMetaData{}
+	if err := thrift.Unmarshal(&protocol, footerData, metadata); err != nil {
+		return nil, fmt.Errorf("reading parquet file metadata: %w", err)
+	}
+	if len(metadata.Schema) == 0 {
+		return nil, errors.New("missing root column")
+	}
+
+	return metadata, nil
+}
+
+type metadataTable struct {
+	schema []format.SchemaElement
+	row    int
+}
+
+func newMetadataTable(m *format.FileMetaData) *metadataTable {
+	return &metadataTable{
+		schema: m.Schema,
+	}
+}
+
+func (t *metadataTable) Header() []interface{} {
+	return []interface{}{
+		"Type",
+		"TypeLength",
+		"RepetitionType",
+		"Name",
+		"NumChildren",
+		"ConvertedType",
+		"Scale",
+		"Precision",
+		"FieldID",
+		"LogicalType",
+	}
+}
+
+func (t *metadataTable) NextRow() (output.TableRow, error) {
+	if t.row >= len(t.schema) {
+		return nil, io.EOF
+	}
+
+	r := newMetadataRow(0, &t.schema[t.row])
+	t.row++
+
+	return r, nil
+}
+
+type metadataRow struct {
+	n int
+	s *format.SchemaElement
+}
+
+func newMetadataRow(n int, s *format.SchemaElement) *metadataRow {
+	return &metadataRow{
+		n: n,
+		s: s,
+	}
+}
+
+func (r *metadataRow) Row() int {
+	return r.n
+}
+
+func (r *metadataRow) Cells() []interface{} {
+	return []interface{}{
+		r.s.Type,
+		r.s.TypeLength,
+		r.s.RepetitionType,
+		r.s.Name,
+		r.s.NumChildren,
+		r.s.ConvertedType,
+		r.s.Scale,
+		r.s.Precision,
+		r.s.FieldID,
+		r.s.LogicalType,
+	}
+}
+
+func (r *metadataRow) Data() interface{} {
+	return r.s
 }


### PR DESCRIPTION
This PR adds a very basic schema dump:

```
$ ./parquet-cli schema ./example/nested.parquet 
Type        TypeLength    RepetitionType  Name    NumChildren  ConvertedType  Scale  Precision  FieldID  LogicalType   
<nil>       <nil>         <nil>           Nested  2            <nil>          <nil>  <nil>      0        <nil>         
INT64       0xc00002f634  REQUIRED        ColA    0            0xc00002f640   <nil>  <nil>      0        INT(64,true)  
<nil>       <nil>         REPEATED        ColB    2            <nil>          <nil>  <nil>      0        <nil>         
BYTE_ARRAY  <nil>         REQUIRED        InnerA  0            0xc00002f660   <nil>  <nil>      0        STRING        
BYTE_ARRAY  <nil>         OPTIONAL        InnerB  0            0xc00002f678   <nil>  <nil>      0        STRING 
```

In order to display these properly nested we may need to expand the output options (or get creative with the table).