### PR TITLE
Sub command to show column statistics

### DIFF
--- a/cmd/parquet-cli/cmd_col_stats.go
+++ b/cmd/parquet-cli/cmd_col_stats.go
@@ -1,13 +1,28 @@
 package main
 
-import "fmt"
+import (
+	"os"
+
+	"github.com/stoewer/parquet-cli/pkg/inspect"
+	"github.com/stoewer/parquet-cli/pkg/output"
+)
 
 type colStats struct {
 	outputOptions
-	File string `arg:""`
+	File    string `arg:""`
+	Columns []int  `short:"c" optional:"" help:"Restrict the output to the following columns"`
 }
 
 func (cs *colStats) Run() error {
-	fmt.Println("Sub command col-stats not implemented yet")
-	return nil
+	file, err := openParquetFile(cs.File)
+	if err != nil {
+		return err
+	}
+
+	rowStats, err := inspect.NewColStatCalculator(file, cs.Columns)
+	if err != nil {
+		return err
+	}
+
+	return output.Print(os.Stdout, cs.Output, rowStats)
 }

--- a/pkg/inspect/col_stats.go
+++ b/pkg/inspect/col_stats.go
@@ -1,0 +1,103 @@
+package inspect
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/parquet-go"
+	"github.com/stoewer/parquet-cli/pkg/output"
+)
+
+var (
+	columnStatHeader = [...]interface{}{"Index", "Name", "Size", "Pages", "Rows", "Values", "Nulls"}
+)
+
+type ColumnStats struct {
+	Index  int    `json:"index"`
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	Pages  int    `json:"pages"`
+	Rows   int64  `json:"rows"`
+	Values int64  `json:"values"`
+	Nulls  int64  `json:"nulls"`
+
+	cells []interface{}
+}
+
+func (rs *ColumnStats) Row() int {
+	return rs.Index
+}
+
+func (rs *ColumnStats) Data() interface{} {
+	return rs
+}
+
+func (rs *ColumnStats) Cells() []interface{} {
+	if rs.cells == nil {
+		rs.cells = []interface{}{
+			rs.Index,
+			rs.Name,
+			rs.Size,
+			rs.Pages,
+			rs.Rows,
+			rs.Values,
+			rs.Nulls,
+		}
+	}
+	return rs.cells
+}
+
+func NewColStatCalculator(file *parquet.File, selectedCols []int) (*ColStatCalculator, error) {
+	all := LeafColumns(file)
+	var columns []*parquet.Column
+
+	if len(selectedCols) == 0 {
+		columns = all
+	} else {
+		columns = make([]*parquet.Column, 0, len(selectedCols))
+		for _, idx := range selectedCols {
+			if idx >= len(all) {
+				return nil, errors.Errorf("column index expectd be below %d but was %d", idx, len(all))
+			}
+			columns = append(columns, all[idx])
+		}
+	}
+
+	return &ColStatCalculator{columns: columns}, nil
+}
+
+type ColStatCalculator struct {
+	columns []*parquet.Column
+	current int
+}
+
+func (cc *ColStatCalculator) Header() []interface{} {
+	return columnStatHeader[:]
+}
+
+func (cc *ColStatCalculator) NextRow() (output.TableRow, error) {
+	if cc.current >= len(cc.columns) {
+		return nil, errors.Wrapf(io.EOF, "stop iteration: no more culumns")
+	}
+
+	col := cc.columns[cc.current]
+	cc.current++
+
+	stats := ColumnStats{Index: col.Index(), Name: col.Name()}
+	pages := col.Pages()
+
+	page, err := pages.ReadPage()
+	for err == nil {
+		stats.Pages++
+		stats.Size += page.Size()
+		stats.Rows += page.NumRows()
+		stats.Values += page.NumValues()
+		stats.Nulls += page.NumNulls()
+		page, err = pages.ReadPage()
+	}
+	if !errors.Is(err, io.EOF) {
+		return nil, errors.Wrapf(err, "unable to read page rom column '%s", col.Name())
+	}
+
+	return &stats, nil
+}

--- a/pkg/inspect/column_row_iter_test.go
+++ b/pkg/inspect/column_row_iter_test.go
@@ -56,7 +56,7 @@ func TestColumnRowIterator_NextRow(t *testing.T) {
 		t.Run(fmt.Sprintf("col %d limit %d offset %d", tt.columnIdx, l, tt.offset), func(t *testing.T) {
 			file := tf.Open(t, filename)
 
-			columns := LeafColumns(file.Root())
+			columns := LeafColumns(file)
 			rows, err := newColumnRowIterator(columns[tt.columnIdx], Pagination{Limit: tt.limit, Offset: tt.offset})
 			require.NoError(t, err)
 
@@ -71,7 +71,7 @@ var globalRow []parquet.Value
 func BenchmarkColumnRowIterator_NextRow(b *testing.B) {
 	filename := tf.New(b, tf.RandomNested(100_000, 10))
 	file := tf.Open(b, filename)
-	cols := LeafColumns(file.Root())
+	cols := LeafColumns(file)
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {

--- a/pkg/inspect/inspect_test.go
+++ b/pkg/inspect/inspect_test.go
@@ -1,0 +1,30 @@
+package inspect
+
+import (
+	"testing"
+
+	tf "github.com/stoewer/parquet-cli/pkg/testfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeafColumns(t *testing.T) {
+	data := []tf.Nested{{
+		ColA: 1,
+		ColB: []tf.Inner{{
+			InnerA: "a",
+			Map: []tf.InnerMap{{
+				Key: "aa",
+				Val: ptr(11),
+			}},
+		}},
+	}}
+
+	file := tf.Open(t, tf.New(t, data))
+	columns := LeafColumns(file)
+	require.Len(t, columns, 4)
+	assert.Equal(t, "ColA", columns[0].Name())
+	assert.Equal(t, "InnerA", columns[1].Name())
+	assert.Equal(t, "Key", columns[2].Name())
+	assert.Equal(t, "Val", columns[3].Name())
+}

--- a/pkg/inspect/row_stats.go
+++ b/pkg/inspect/row_stats.go
@@ -52,7 +52,7 @@ func NewRowStatCalculator(file *parquet.File, options RowStatOptions) (*RowStatC
 		col *parquet.Column
 	}
 
-	all := LeafColumns(file.Root())
+	all := LeafColumns(file)
 	var columns []indexedColumn
 
 	if len(options.SelectedCols) == 0 {


### PR DESCRIPTION
The col-stat sub command shows information about the size, pages, rows, and values in a column:

```
./parquet-cli col-stats ./example/nested.parquet 
```