### PR TITLE
Sub command to print the fil content or parts of the content

### DIFF
--- a/cmd/parquet-cli/cmd_dump.go
+++ b/cmd/parquet-cli/cmd_dump.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"errors"
+	"os"
+
+	"github.com/stoewer/parquet-cli/pkg/inspect"
+	"github.com/stoewer/parquet-cli/pkg/output"
+)
+
+type dump struct {
+	outputOptions
+	File    string `arg:""`
+	Columns []int  `short:"c" optional:"" help:"Restrict the output to the following columns"`
+	Limit   *int64 `optional:"" help:"Limit the output to the given number of rows"`
+	Offset  int64  `optional:"" help:"Begin the output at this row offset"`
+}
+
+func (d *dump) Run() error {
+	if d.Output == output.FormatJSON {
+		return errors.New("JSON output not supported for dump command")
+	}
+
+	file, err := openParquetFile(d.File)
+	if err != nil {
+		return err
+	}
+
+	options := inspect.RowStatOptions{
+		SelectedCols: d.Columns,
+		Pagination: inspect.Pagination{
+			Limit:  d.Limit,
+			Offset: d.Offset,
+		},
+	}
+
+	rowDump, err := inspect.NewRowDump(file, options)
+	if err != nil {
+		return err
+	}
+
+	return output.Print(os.Stdout, d.Output, rowDump)
+}

--- a/cmd/parquet-cli/main.go
+++ b/cmd/parquet-cli/main.go
@@ -9,6 +9,7 @@ var cli struct {
 	Schema   schema   `cmd:"" help:"Print the files schema"`
 	ColStats colStats `cmd:"" help:"Show column numbers and statistics from a file"`
 	RowStats rowStats `cmd:"" help:"Show statistics about each row in a file"`
+	Dump     dump     `cmd:"" help:"Print the content of the file"`
 }
 
 type outputOptions struct {

--- a/pkg/inspect/col_stats.go
+++ b/pkg/inspect/col_stats.go
@@ -44,10 +44,6 @@ type ColumnStats struct {
 	cells []interface{}
 }
 
-func (rs *ColumnStats) Row() int {
-	return rs.Index
-}
-
 func (rs *ColumnStats) Data() interface{} {
 	return rs
 }

--- a/pkg/inspect/row_dump.go
+++ b/pkg/inspect/row_dump.go
@@ -1,0 +1,139 @@
+package inspect
+
+import (
+	"github.com/pkg/errors"
+	"github.com/segmentio/parquet-go"
+	"github.com/stoewer/parquet-cli/pkg/output"
+)
+
+type DumpLine struct {
+	RowNumber *int
+	Line      []*parquet.Value
+}
+
+func (d *DumpLine) Data() interface{} {
+	return d.Line
+}
+
+func (d *DumpLine) Cells() []interface{} {
+	cells := make([]interface{}, 0, len(d.Line)+1)
+	if d.RowNumber == nil {
+		cells = append(cells, "")
+	} else {
+		cells = append(cells, *d.RowNumber)
+	}
+
+	for _, v := range d.Line {
+		if v == nil {
+			cells = append(cells, "")
+		} else {
+			cells = append(cells, v)
+		}
+	}
+	return cells
+}
+
+type RowDumpOptions struct {
+	Pagination
+	SelectedCols []int
+}
+
+func NewRowDump(file *parquet.File, options RowStatOptions) (*RowDump, error) {
+	all := LeafColumns(file)
+	var columns []*parquet.Column
+
+	if len(options.SelectedCols) == 0 {
+		columns = all
+	} else {
+		columns = make([]*parquet.Column, 0, len(options.SelectedCols))
+		for _, idx := range options.SelectedCols {
+			if idx >= len(all) {
+				return nil, errors.Errorf("column index expectd be below %d but was %d", idx, len(all))
+			}
+			columns = append(columns, all[idx])
+		}
+	}
+
+	c := RowDump{
+		header:     make([]interface{}, 0, len(columns)+1),
+		columnIter: make([]*columnRowIterator, 0, len(columns)),
+		row: rowValues{
+			values: make([][]parquet.Value, len(columns)),
+		},
+	}
+
+	c.header = append(c.header, "Row")
+	for _, col := range columns {
+		it, err := newColumnRowIterator(col, options.Pagination)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to create row stats calculator")
+		}
+		c.columnIter = append(c.columnIter, it)
+		c.header = append(c.header, col.Name())
+	}
+
+	return &c, nil
+}
+
+type rowValues struct {
+	values [][]parquet.Value
+	index  int
+}
+
+type RowDump struct {
+	header     []interface{}
+	columnIter []*columnRowIterator
+	rowNumber  int
+	row        rowValues
+}
+
+func (rd *RowDump) Header() []interface{} {
+	return rd.header
+}
+
+func (rd *RowDump) NextRow() (output.TableRow, error) {
+	if !rd.hasUnreadRowValues() {
+		err := rd.readRowValues()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dl := DumpLine{Line: make([]*parquet.Value, 0, len(rd.row.values))}
+	if rd.row.index == 0 {
+		dl.RowNumber = &rd.rowNumber
+	}
+
+	for _, vals := range rd.row.values {
+		if rd.row.index < len(vals) {
+			dl.Line = append(dl.Line, &vals[rd.row.index])
+		} else {
+			dl.Line = append(dl.Line, nil)
+		}
+	}
+	rd.row.index++
+
+	return &dl, nil
+}
+
+func (rd *RowDump) hasUnreadRowValues() bool {
+	for _, vals := range rd.row.values {
+		if rd.row.index < len(vals) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rd *RowDump) readRowValues() error {
+	for i, it := range rd.columnIter {
+		vals, err := it.NextRow()
+		if err != nil {
+			return err
+		}
+		rd.row.values[i] = vals
+	}
+	rd.rowNumber++
+	rd.row.index = 0
+	return nil
+}

--- a/pkg/inspect/row_stats.go
+++ b/pkg/inspect/row_stats.go
@@ -24,10 +24,6 @@ type RowStats struct {
 	Stats     []CellStats
 }
 
-func (rs *RowStats) Row() int {
-	return rs.RowNumber
-}
-
 func (rs *RowStats) Data() interface{} {
 	return rs.Stats
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -22,8 +22,10 @@ const (
 
 func (f *Format) Validate() error {
 	switch *f {
-	case FormatJSON, FormatCSV, FormatTab:
+	case FormatJSON, FormatTab:
 		return nil
+	case FormatCSV:
+		return errors.New("output format CSV is supported yet :-(")
 	default:
 		return errors.New("output format is expected to be 'json', 'tab', or 'csv'")
 	}
@@ -39,8 +41,6 @@ type Table interface {
 
 // A TableRow represents all data that belongs to a table row.
 type TableRow interface {
-	// Row returns the number of this table row.
-	Row() int
 	// Cells returns all table cells for this row. This is used to
 	// print tabular formats such csv. The returned slice has the same
 	// length as the header slice returned by the parent Table.


### PR DESCRIPTION
The `dump` sub command prints the content of the file. It is also possible to limit the output to certain columns or rows.

Example:
```
./parquet-cli dump --limit 1 --offset 2 --columns 1,2 ./example/nested.parquet
```

Prints:
```
Row  InnerA  Key  
1    d       dd   
     e       ee   
             ff   
```