### PR TITLE
Add compressed size to col-stats sub command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,8 +27,10 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
+  use: github-native
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
-      - '^example:'
+      - '^[Dd]ocs:'
+      - '^[Tt]est:'
+      - '^CI:'
+      - 'typo'

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -78,21 +78,13 @@ func printTab(w io.Writer, data Table) error {
 		return err
 	}
 
-	var count int
 	row, err := data.NextRow()
 	for err == nil {
 		_, err = fmt.Fprintf(tw, format, row.Cells()...)
 		if err != nil {
 			return err
 		}
-		if count > 0 && count%10 == 0 {
-			err = tw.Flush()
-			if err != nil {
-				return err
-			}
-		}
 
-		count++
 		row, err = data.NextRow()
 	}
 	if err != nil && !errors.Is(err, io.EOF) {


### PR DESCRIPTION
The sub command for column statistics now also shows the compressed size of each column